### PR TITLE
Retry if there was a rpc error

### DIFF
--- a/service/common/states.go
+++ b/service/common/states.go
@@ -32,3 +32,5 @@ const (
 	TransactionStateFailed   TransactionState = "failed"
 	TransactionStateComplete TransactionState = "complete"
 )
+
+const TransactionRPCErrorString string = "rpc error"


### PR DESCRIPTION
Retry a transaction on rpc errors, ie:

```
error while sending transaction: client: rpc error: code = Internal desc = failed to send transaction to a collection node: 3 errors occurred:
	* failed to send transaction to collection node at flow-1.staked.cloud:3569: rpc error: code = DeadlineExceeded desc = context deadline exceeded
	* failed to send transaction to collection node at p2p.240cb98b-097c-4473-8db7-e018030fec00.flow.bison.run:3569: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial tcp: lookup p2p.240cb98b-097c-4473-8db7-e018030fec00.flow.bison.run on 169.254.169.254:53: no such host"
	* failed to send transaction to collection node at flow-0.staked.cloud:3569: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```