### PR TITLE
Fix collection initialization

### DIFF
--- a/cadence-transactions/packNFT/create_new_packNFT_collection.cdc
+++ b/cadence-transactions/packNFT/create_new_packNFT_collection.cdc
@@ -5,10 +5,10 @@ transaction() {
     prepare (issuer: AuthAccount) {
         
         // Check if account already have a PackIssuer resource, if so destroy it
-        if issuer.borrow<&PackNFT.Collection>(from: PackNFT.CollectionStoragePath) != nil {
-            issuer.unlink(PackNFT.CollectionPublicPath)
-            let p <- issuer.load<@PackNFT.Collection>(from: PackNFT.CollectionStoragePath) 
-            destroy p
+        if issuer.borrow<&PackNFT.Collection>(from: PackNFT.CollectionStoragePath) == nil {
+            issuer.save(<-PackNFT.createEmptyCollection(), to: PackNFT.CollectionStoragePath);
+            issuer.link<&{NonFungibleToken.CollectionPublic}>(PackNFT.CollectionPublicPath, target: PackNFT.CollectionStoragePath)
+                ?? panic("Could not link PackNFT.Collection Pub Path");
         }
         
         issuer.save(<- PackNFT.createEmptyCollection(), to: PackNFT.CollectionStoragePath);

--- a/cadence-transactions/packNFT/create_new_packNFT_collection.cdc
+++ b/cadence-transactions/packNFT/create_new_packNFT_collection.cdc
@@ -4,17 +4,12 @@ import NonFungibleToken from 0x{{.NonFungibleToken}}
 transaction() {
     prepare (issuer: AuthAccount) {
         
-        // Check if account already have a PackIssuer resource, if so destroy it
+         // Only initialize account if doesn't have a PackNFT.Collection resource
         if issuer.borrow<&PackNFT.Collection>(from: PackNFT.CollectionStoragePath) == nil {
             issuer.save(<-PackNFT.createEmptyCollection(), to: PackNFT.CollectionStoragePath);
             issuer.link<&{NonFungibleToken.CollectionPublic}>(PackNFT.CollectionPublicPath, target: PackNFT.CollectionStoragePath)
                 ?? panic("Could not link PackNFT.Collection Pub Path");
         }
-        
-        issuer.save(<- PackNFT.createEmptyCollection(), to: PackNFT.CollectionStoragePath);
-        
-        issuer.link<&{NonFungibleToken.CollectionPublic}>(PackNFT.CollectionPublicPath, target: PackNFT.CollectionStoragePath)
-        ??  panic("Could not link Collection Pub Path");
-    } 
+    }
 }
  


### PR DESCRIPTION
Instead of overwriting existing collection, check if it exists instead. If it doesn't exist, initialize a new collection.