### PR TITLE
bump to latest versions of cadence, emulator, sdk

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
   emulator:
     env:
-      FLOW_CLI_VERSION: v0.35.2
+      FLOW_CLI_VERSION: v0.36.2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
   emulator:
     env:
-      FLOW_CLI_VERSION: v0.35.0
+      FLOW_CLI_VERSION: v0.35.2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_PASSWORD=test
 
   test-emulator:
-    image: gcr.io/flow-container-registry/emulator:0.33.1
+    image: gcr.io/flow-container-registry/emulator:0.33.2
     restart: unless-stopped
     command: emulator
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "5050:80"
 
   emulator:
-    image: gcr.io/flow-container-registry/emulator:0.33.0
+    image: gcr.io/flow-container-registry/emulator:0.33.2
     restart: unless-stopped
     command: emulator
     ports:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/joho/godotenv v1.4.0
 	github.com/onflow/cadence v0.24.4
-	github.com/onflow/flow-go v0.26.3
+	github.com/onflow/flow-go v0.26.9
 	github.com/onflow/flow-go-sdk v0.26.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/joho/godotenv v1.4.0
-	github.com/onflow/cadence v0.24.3
+	github.com/onflow/cadence v0.24.4
 	github.com/onflow/flow-go v0.26.3
-	github.com/onflow/flow-go-sdk v0.26.2
+	github.com/onflow/flow-go-sdk v0.26.3
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	github.com/trailofbits/go-mutexasserts v0.0.0-20200708152505-19999e7d3cef

--- a/go.sum
+++ b/go.sum
@@ -1440,6 +1440,7 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x071HgCF/0v5hQcaE5qqjc2UqN5gCU8h5Mk6uqpOg=
 github.com/onflow/atree v0.1.1/go.mod h1:95SqSEPgfijF1ZkLKbVgYVrfQzvP0fhayh555v1oLbs=
 github.com/onflow/atree v0.3.0/go.mod h1:tSPKjdmbNOQyVrSvcxKZG8+EDL4jdjoJBGAjNVk8zkA=
+github.com/onflow/atree v0.3.1-0.20220519142403-b0077ba343ec/go.mod h1:ujKt3moaqv8Cv236rYpSoxNpHzNUy4Wih0U4GPvPZ1g=
 github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a h1:ldQ7U2iddVJCwJA2ckK7y6AdH4INzxOSu2VnejkcBro=
 github.com/onflow/atree v0.3.1-0.20220531231935-525fbc26f40a/go.mod h1:PZESmRR4bI/w/9nEDCqRoWxBq/jFNUEzkfypHf0j8cw=
 github.com/onflow/cadence v0.14.2/go.mod h1:EEXKRNuW5C2E1wRM4fLhfqoTgXohPFieXwOGJubz1Jg=
@@ -1456,9 +1457,11 @@ github.com/onflow/cadence v0.21.3-0.20220419065337-d5202c162010/go.mod h1:vNIxF1
 github.com/onflow/cadence v0.21.3-0.20220509200929-9a1afbeeb449/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/cadence v0.21.3-0.20220511225809-808fe14141df/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
 github.com/onflow/cadence v0.21.3-0.20220513161637-08b93d4bb7b9/go.mod h1:vNIxF13e1Ty50KnkQSm6LVwvxGGLTQ4kpldvTL+2S6s=
+github.com/onflow/cadence v0.21.3-0.20220524232221-b4a37c41632f/go.mod h1:MfEvTq9dvGhnoyqUqsKBsZBM5V4SytllHMqHM+6Lki0=
 github.com/onflow/cadence v0.21.3-0.20220601002855-8b113c539a2c/go.mod h1:FliGP1FZLEuSemnSf8pKItDzW7E2cvPukx/SsE1+oCo=
 github.com/onflow/cadence v0.24.0/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/cadence v0.24.1/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
+github.com/onflow/cadence v0.24.3/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/cadence v0.24.4 h1:3f7wk1WFKvBlwjh3d1//5frJKFgECK2GxljoG4wzQqs=
 github.com/onflow/cadence v0.24.4/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/cadence/languageserver v0.15.2/go.mod h1:hQGE8dYH5CfQ1Oe0nXglchgURzZwR3JQhmuXtv4ROHs=
@@ -1473,6 +1476,7 @@ github.com/onflow/fcl-dev-wallet v0.4.2/go.mod h1:xWVEyGZgdDt4/+PLSlpuqhtzobjnWy
 github.com/onflow/flow v0.2.3-0.20220131193101-d4e2ca43a621/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow v0.2.4/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow v0.2.5/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
+github.com/onflow/flow v0.3.0/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow v0.3.1 h1:kL/tNvCXeBw4yCVPys/m9rxvKxrO7Ck/mVNqHFtkTrI=
 github.com/onflow/flow v0.3.1/go.mod h1:lzyAYmbu1HfkZ9cfnL5/sjrrsnJiUU8fRL26CqLP7+c=
 github.com/onflow/flow-cli v0.20.3-0.20210512000809-474effb7e7db/go.mod h1:Yh4dgrNiZdXhbU+3UVUmo4gRM0TEBVvhW4ITKVo82dg=
@@ -1511,6 +1515,7 @@ github.com/onflow/flow-emulator v0.29.0-sc/go.mod h1:zsocr7EBhku+9q5qGadrb8L1F/w
 github.com/onflow/flow-emulator v0.30.1-0.20220421153717-0a0abc4d580b/go.mod h1:5IsytpArI/wN2ZZXCRAAcIp/223PmVDnmPxbRZO6IbU=
 github.com/onflow/flow-emulator v0.31.2-0.20220421202209-eb83f9bfda53/go.mod h1:4jyaXs+wHHI0JlBi3/+K9DciPzIve3+MFrNXRAnBEl4=
 github.com/onflow/flow-emulator v0.31.2-0.20220513151845-ef7513cb1cd0/go.mod h1:XLZfTEaYX2151TcTvZPIj7taBN0qpsOoyvEBRZzlXtQ=
+github.com/onflow/flow-emulator v0.32.0-beta1/go.mod h1:o2HLEehv7H8QTz7pI/WhdWQgIgSn1bY2PDcuhSgCieU=
 github.com/onflow/flow-emulator v0.32.0/go.mod h1:S8TLiS1clQl5GEsHdJ7V7BcRfU3dAwg1RWV6dLgp1cI=
 github.com/onflow/flow-emulator v0.32.1-0.20220608200416-af3f5ba3f673/go.mod h1:1HEDTQqXL2PUFRAJmKKs0/YgPUKgGSeIziwBeIBOTjM=
 github.com/onflow/flow-emulator v0.32.1-0.20220608220535-c3d005f9ac92/go.mod h1:LdwNLQPNOUlB5extFJohIOzsnhbZhPhC7HzrStex6L8=
@@ -1528,10 +1533,12 @@ github.com/onflow/flow-go v0.25.1-0.20220317203627-1c99893f6f6a/go.mod h1:AwVzaD
 github.com/onflow/flow-go v0.25.8-0.20220420171205-833e2e8849b1/go.mod h1:tXHoKoHvUoS+xqmNI+5rJ1bzvWPLkFgH4GAs8iRESC0=
 github.com/onflow/flow-go v0.25.13-0.20220421201202-a0a5911268b6/go.mod h1:DhXeK/9n3dAe7b1hxdxdq0BNbv53+2IwoYGJ1VK5MFc=
 github.com/onflow/flow-go v0.25.13-0.20220513151142-7858f76e703b/go.mod h1:GU4O0LFkSHnuTvyi03bax+ANAUVf3EZ5YsH8biZQsG4=
+github.com/onflow/flow-go v0.25.13-0.20220527181337-e50ac5fe58da/go.mod h1:go60rzhCrYS+0J3Q3pT9NwbuDsZjf+acZmwTlZ90j2Q=
 github.com/onflow/flow-go v0.25.13-0.20220609230330-ac8d2d78c212/go.mod h1:sYytNEocAABNMNEPxvtbhYxhHpd4ljtHYn3AC9UUC1I=
 github.com/onflow/flow-go v0.26.2/go.mod h1:RCc7ztvK/XEuN5G6CYyO7x50Lfz+hSvS/HSdVsLf/Wk=
-github.com/onflow/flow-go v0.26.3 h1:q1af+gkJd4xzxICtzkOHAopcX4kntozuNgr53iKcVHI=
 github.com/onflow/flow-go v0.26.3/go.mod h1:MDUuR+YWgmiW9XY1bW7FOFcsULBCoG5VNr87EQbtyDk=
+github.com/onflow/flow-go v0.26.9 h1:qlsWZGwJq8qHusP3+Ln2aBCNhQjjpm+UE3aSCaWfqQQ=
+github.com/onflow/flow-go v0.26.9/go.mod h1:8yLnOCJpZRGbkoDEzBexJTEb/BmqYQTi5z4XG1kBqRo=
 github.com/onflow/flow-go-sdk v0.18.0/go.mod h1:AjXHdxguP/PK5P8tWKHH4jR6oLISTgLoXXQrbQsHY+E=
 github.com/onflow/flow-go-sdk v0.19.0/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
 github.com/onflow/flow-go-sdk v0.20.0-alpha.1/go.mod h1:52QZyLwU3p3UZ2FXOy+sRl4JPdtvJoae1spIUBOFxA8=
@@ -1543,6 +1550,7 @@ github.com/onflow/flow-go-sdk v0.24.1-0.20220512181452-dec47e8451bb/go.mod h1:KQ
 github.com/onflow/flow-go-sdk v0.24.1-0.20220513205729-d1f58d47c4e3/go.mod h1:cDUwD383pSyvlKueB7lxNI10/mfS+2EWeZOmeJaxZiE=
 github.com/onflow/flow-go-sdk v0.26.0/go.mod h1:PzRE6FkdcIEl10M3H/cRnsj8SRJzKgaXqQCvLO1cOL0=
 github.com/onflow/flow-go-sdk v0.26.1/go.mod h1:Z0SxMQgapt5aBgIdI3trG+IvAAux8WAvCKhgZ7tP6dQ=
+github.com/onflow/flow-go-sdk v0.26.2/go.mod h1:wjeLjPVcZ2z3xNwvtRDj3ojqnJEoqGoxQOa3eHHXo18=
 github.com/onflow/flow-go-sdk v0.26.3 h1:LEowsVrCp81fV1yzFGdL0CrT1V1iv+qy8QBONtP568U=
 github.com/onflow/flow-go-sdk v0.26.3/go.mod h1:lGce072IVVj1EWn6C8xPJcvaGyNwp4AdOMHYcJsORK8=
 github.com/onflow/flow-go/crypto v0.12.0/go.mod h1:oXuvU0Dr4lHKgye6nHEFbBXIWNv+dBQUzoVW5Go38+o=
@@ -1560,6 +1568,7 @@ github.com/onflow/flow/protobuf/go/flow v0.2.3/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2m
 github.com/onflow/flow/protobuf/go/flow v0.2.4-0.20220304041411-6d91cd04a33a/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/flow/protobuf/go/flow v0.2.4/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/flow/protobuf/go/flow v0.2.5/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
+github.com/onflow/flow/protobuf/go/flow v0.3.0/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/flow/protobuf/go/flow v0.3.1 h1:4I8ykG6naR3n8Or6eXrZDaGVaoztb3gP2KJ6XKyDufg=
 github.com/onflow/flow/protobuf/go/flow v0.3.1/go.mod h1:gQxYqCfkI8lpnKsmIjwtN2mV/N2PIwc1I+RUK4HPIc8=
 github.com/onflow/fusd/lib/go/contracts v0.0.0-20211021081023-ae9de8fb2c7e/go.mod h1:CRX9eXtc9zHaRVTW1Xh4Cf5pZgKkQuu1NuSEVyHXr/0=

--- a/go.sum
+++ b/go.sum
@@ -1459,8 +1459,8 @@ github.com/onflow/cadence v0.21.3-0.20220513161637-08b93d4bb7b9/go.mod h1:vNIxF1
 github.com/onflow/cadence v0.21.3-0.20220601002855-8b113c539a2c/go.mod h1:FliGP1FZLEuSemnSf8pKItDzW7E2cvPukx/SsE1+oCo=
 github.com/onflow/cadence v0.24.0/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/cadence v0.24.1/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
-github.com/onflow/cadence v0.24.3 h1:UhggdTeTbxZraB9vkR7TlRv3i05nHDisFzo8SNzDZ0c=
-github.com/onflow/cadence v0.24.3/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
+github.com/onflow/cadence v0.24.4 h1:3f7wk1WFKvBlwjh3d1//5frJKFgECK2GxljoG4wzQqs=
+github.com/onflow/cadence v0.24.4/go.mod h1:tIJiQ4RIq1WUTXdBewv8p+gNUETN93Eb7jSFedjqs5w=
 github.com/onflow/cadence/languageserver v0.15.2/go.mod h1:hQGE8dYH5CfQ1Oe0nXglchgURzZwR3JQhmuXtv4ROHs=
 github.com/onflow/cadence/languageserver v0.16.0/go.mod h1:UPV1so9LcMrhj27IegrTucoyS4TLRVjNr4DJqjqBhFA=
 github.com/onflow/cadence/languageserver v0.18.2/go.mod h1:ehuDCUevEEavUzgJqLevcZPjfmTzMBX7Sglbi5ur9uU=
@@ -1543,8 +1543,8 @@ github.com/onflow/flow-go-sdk v0.24.1-0.20220512181452-dec47e8451bb/go.mod h1:KQ
 github.com/onflow/flow-go-sdk v0.24.1-0.20220513205729-d1f58d47c4e3/go.mod h1:cDUwD383pSyvlKueB7lxNI10/mfS+2EWeZOmeJaxZiE=
 github.com/onflow/flow-go-sdk v0.26.0/go.mod h1:PzRE6FkdcIEl10M3H/cRnsj8SRJzKgaXqQCvLO1cOL0=
 github.com/onflow/flow-go-sdk v0.26.1/go.mod h1:Z0SxMQgapt5aBgIdI3trG+IvAAux8WAvCKhgZ7tP6dQ=
-github.com/onflow/flow-go-sdk v0.26.2 h1:60wimtE4NX1poBtUiEYa2+FrtYGkwVd7Sl4L/GVgaiw=
-github.com/onflow/flow-go-sdk v0.26.2/go.mod h1:wjeLjPVcZ2z3xNwvtRDj3ojqnJEoqGoxQOa3eHHXo18=
+github.com/onflow/flow-go-sdk v0.26.3 h1:LEowsVrCp81fV1yzFGdL0CrT1V1iv+qy8QBONtP568U=
+github.com/onflow/flow-go-sdk v0.26.3/go.mod h1:lGce072IVVj1EWn6C8xPJcvaGyNwp4AdOMHYcJsORK8=
 github.com/onflow/flow-go/crypto v0.12.0/go.mod h1:oXuvU0Dr4lHKgye6nHEFbBXIWNv+dBQUzoVW5Go38+o=
 github.com/onflow/flow-go/crypto v0.18.0/go.mod h1:3Ah843iPyjIL+7nH9EillV3OWNptrL+DrQUbVKgg2E4=
 github.com/onflow/flow-go/crypto v0.21.3/go.mod h1:vI6V4CY3R6c4JKBxdcRiR/AnjBfL8OSD97bJc60cLuQ=


### PR DESCRIPTION
cadence v0.24.4
flow-go v0.26.3
flow-go-sdk v0.26.3
emulator 0.33.2
flow cli v0.35.2