### PR TITLE
Add handler for updating distr complete

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,5 +72,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42
+          version: v1.45
           args: --timeout=3m --tests=true

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -392,6 +392,10 @@ func TestE2E(t *testing.T) {
 	t.Logf("Owner collectible NFTs before: %s\n", ownerCollectibleNFTsBefore.String())
 	t.Logf("Owner collectible NFTs after:  %s\n", ownerCollectibleNFTsAfter.String())
 
+	if err := a.UpdateDistributionComplete(context.Background(), distribution.ID); err != nil {
+		t.Fatal(err)
+	}
+
 	distStateScript := "./cadence-scripts/pds/get_dist_state.cdc"
 	distStateCode := util.ParseCadenceTemplate(distStateScript)
 	distStateR, err := g.Script(string(distStateCode)).

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -90,7 +90,7 @@ func (app *App) UpdateDistributionComplete(ctx context.Context, id uuid.UUID) er
 			return err
 		}
 
-		return app.service.UpdateDistributionComplete(ctx, app.db, distribution)
+		return app.service.UpdateDistributionCompleteOnChain(ctx, app.db, distribution)
 	})
 }
 

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -82,6 +82,18 @@ func (app *App) CreateDistribution(ctx context.Context, distribution *Distributi
 	return nil
 }
 
+// UpdateDistributionComplete updates the distribution state to complete
+func (app *App) UpdateDistributionComplete(ctx context.Context, id uuid.UUID) error {
+	return app.db.Transaction(func(tx *gorm.DB) error {
+		distribution, err := GetDistributionSmall(tx, id)
+		if err != nil {
+			return err
+		}
+
+		return app.service.UpdateDistributionComplete(ctx, app.db, distribution)
+	})
+}
+
 // ListDistributions lists all distributions in the database. Uses 'limit' and 'offset' to
 // limit the fetched slice size.
 func (app *App) ListDistributions(ctx context.Context, limit, offset int) ([]Distribution, error) {

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -114,6 +114,9 @@ func (svc *ContractService) SetDistCap(ctx context.Context, db *gorm.DB, issuer 
 	return nil
 }
 
+// UpdateDistributionCompleteOnChain updates the distribution state on-chain to `complete`.
+// It validates that the distribution state is "complete" in the db,
+// which is updated by the poller in handleMinting (minting state -> complete state) when minting is complete
 func (svc *ContractService) UpdateDistributionCompleteOnChain(ctx context.Context, db *gorm.DB, dist *Distribution) error {
 	logger := log.WithFields(log.Fields{
 		"method":     "UpdateDistributionCompleteOnChain",

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -123,15 +123,6 @@ func (svc *ContractService) UpdateDistributionComplete(ctx context.Context, db *
 
 	logger.Trace("Update distribution complete")
 
-	minting, err := GetDistributionMinting(db, dist.ID)
-	if err != nil {
-		return err // rollback
-	}
-
-	if !minting.IsComplete() {
-		// Minting is not yet complete. Return early
-		return nil
-	}
 	// Distribution is now complete
 	logger.Info("Minting complete")
 

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -816,9 +816,9 @@ func (svc *ContractService) UpdateMintingStatus(ctx context.Context, db *gorm.DB
 	}
 
 	if minting.IsComplete() {
-		// Initial minting is now complete
+		// Distribution is now complete
 
-		// Make sure the distribution is in correct state
+		// TODO: consider updating the distribution separately
 		if err := dist.SetComplete(); err != nil {
 			return err // rollback
 		}
@@ -828,7 +828,7 @@ func (svc *ContractService) UpdateMintingStatus(ctx context.Context, db *gorm.DB
 			return err // rollback
 		}
 
-		logger.Info("Minting complete. Distribution set to complete")
+		logger.Info("Minting complete")
 	}
 
 	minting.StartAtBlock = end
@@ -837,8 +837,6 @@ func (svc *ContractService) UpdateMintingStatus(ctx context.Context, db *gorm.DB
 	if err := UpdateMinting(db, minting); err != nil {
 		return err // rollback
 	}
-
-	logger.Trace("Update minting status complete")
 
 	return nil // commit
 }

--- a/service/app/distribution.go
+++ b/service/app/distribution.go
@@ -185,7 +185,7 @@ func (dist *Distribution) SetIdle() error {
 
 // SetComplete sets the status to "complete" if preceding state was valid
 func (dist *Distribution) SetComplete() error {
-	return dist.SetState(common.DistributionStateComplete, common.DistributionStateMinting)
+	return dist.SetState(common.DistributionStateComplete, common.DistributionStateIdle)
 }
 
 // SetInvalid sets the status to "invalid" if preceding state was valid

--- a/service/app/distribution.go
+++ b/service/app/distribution.go
@@ -178,6 +178,11 @@ func (dist *Distribution) SetMinting() error {
 	return dist.SetState(common.DistributionStateMinting, common.DistributionStateSettled)
 }
 
+// SetIdle sets the status to "idle" if preceding state was valid
+func (dist *Distribution) SetIdle() error {
+	return dist.SetState(common.DistributionStateIdle, common.DistributionStateComplete)
+}
+
 // SetComplete sets the status to "complete" if preceding state was valid
 func (dist *Distribution) SetComplete() error {
 	return dist.SetState(common.DistributionStateComplete, common.DistributionStateMinting)

--- a/service/app/distribution.go
+++ b/service/app/distribution.go
@@ -178,14 +178,14 @@ func (dist *Distribution) SetMinting() error {
 	return dist.SetState(common.DistributionStateMinting, common.DistributionStateSettled)
 }
 
-// SetIdle sets the status to "idle" if preceding state was valid
-func (dist *Distribution) SetIdle() error {
-	return dist.SetState(common.DistributionStateIdle, common.DistributionStateComplete)
-}
-
 // SetComplete sets the status to "complete" if preceding state was valid
 func (dist *Distribution) SetComplete() error {
-	return dist.SetState(common.DistributionStateComplete, common.DistributionStateIdle)
+	return dist.SetState(common.DistributionStateComplete, common.DistributionStateMinting)
+}
+
+// IsComplete checks if the status is "complete"
+func (dist *Distribution) IsComplete() bool {
+	return dist.State != common.DistributionStateComplete
 }
 
 // SetInvalid sets the status to "invalid" if preceding state was valid

--- a/service/common/states.go
+++ b/service/common/states.go
@@ -12,7 +12,6 @@ const (
 	DistributionStateSettling DistributionState = "settling"
 	DistributionStateSettled  DistributionState = "settled"
 	DistributionStateMinting  DistributionState = "minting"
-	DistributionStateIdle     DistributionState = "idle"
 	DistributionStateComplete DistributionState = "complete"
 )
 

--- a/service/common/states.go
+++ b/service/common/states.go
@@ -12,6 +12,7 @@ const (
 	DistributionStateSettling DistributionState = "settling"
 	DistributionStateSettled  DistributionState = "settled"
 	DistributionStateMinting  DistributionState = "minting"
+	DistributionStateIdle     DistributionState = "idle"
 	DistributionStateComplete DistributionState = "complete"
 )
 

--- a/service/http/handlers.go
+++ b/service/http/handlers.go
@@ -71,6 +71,25 @@ func HandleCreateDistribution(logger *log.Logger, app *app.App) http.HandlerFunc
 	}
 }
 
+// Update distribution to complete
+func HandleUpdateDistributionComplete(logger *log.Logger, app *app.App) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		id, err := uuid.Parse(vars["id"])
+		if err != nil {
+			handleError(rw, logger, err)
+			return
+		}
+
+		if err := app.UpdateDistributionComplete(r.Context(), id); err != nil {
+			handleError(rw, logger, err)
+			return
+		}
+
+		handleJsonResponse(rw, http.StatusOK, "Ok")
+	}
+}
+
 // List distributions
 func HandleListDistributions(logger *log.Logger, app *app.App) http.HandlerFunc {
 	return func(rw http.ResponseWriter, r *http.Request) {

--- a/service/http/router.go
+++ b/service/http/router.go
@@ -24,6 +24,7 @@ func NewRouter(app *app.App) http.Handler {
 	rv.HandleFunc("/distributions", HandleCreateDistribution(requestLogger, app)).Methods(http.MethodPost)
 	rv.HandleFunc("/distributions", HandleListDistributions(requestLogger, app)).Methods(http.MethodGet)
 	rv.HandleFunc("/distributions/{id}", HandleGetDistribution(requestLogger, app)).Methods(http.MethodGet)
+	rv.HandleFunc("/distributions/{id}/updatestate", HandleUpdateDistributionComplete(requestLogger, app)).Methods(http.MethodPatch)
 	rv.HandleFunc("/distributions/{id}/abort", HandleAbortDistribution(requestLogger, app)).Methods(http.MethodPost)
 
 	// Add the pprof routes


### PR DESCRIPTION
Ref: https://github.com/dapperlabs/nba-api/issues/9699
- Decouple distribution offchain state `complete` from on-chain state
- Create new endpoint to mark distribution as `complete` on-chain
- Off-chain `complete` state of a distribution indicates that the batch of distribution has completely minting. On-chain `complete` state of a distribution indicates that there is no further intention of minting more collectibles for the given distribution flowID